### PR TITLE
Shape bounds method

### DIFF
--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Drawing;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
@@ -266,27 +267,22 @@ namespace Apos.Shapes {
             // TODO: Restore old states like rasterizer, depth stencil, blend state?
         }
         
-        public Rectangle Bounds() {
-            if (_vertexCount == 0) return Rectangle.Empty;
+        public RectangleF Bounds()
+        {
+            if (_vertexCount == 0) 
+                return RectangleF.Empty;
 
-            var xMin = float.MaxValue;
-            var xMax = float.MinValue;
-            var yMin = float.MaxValue;
-            var yMax = float.MinValue;
-            var zMin = float.MaxValue;
-            var zMax = float.MinValue;
+            var min = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            var max = new Vector3(float.MinValue, float.MinValue, float.MinValue);
 
-            for (int i = 0; i < _vertexCount; i++) {
+            for (var i = 0; i < _vertexCount; i++)
+            {
                 var v = _vertices[i].Position;
-                xMin = MathF.Min(xMin, v.X);
-                xMax = MathF.Max(xMax, v.X);
-                yMin = MathF.Min(yMin, v.Y);
-                yMax = MathF.Max(yMax, v.Y);
-                zMin = MathF.Min(zMin, v.Z);
-                zMax = MathF.Max(zMax, v.Z);
+                min = Vector3.Min(min, v);
+                max = Vector3.Max(max, v);
             }
 
-            return new Rectangle((int)xMin, (int)yMin, (int)(xMax - xMin), (int)(yMax - yMin));
+            return new RectangleF(min.X, min.Y, max.X - min.X, max.Y - min.Y);
         }
 
         private void Flush() {

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using Color = Microsoft.Xna.Framework.Color;
 
 namespace Apos.Shapes {
     public class ShapeBatch {

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -265,6 +265,29 @@ namespace Apos.Shapes {
 
             // TODO: Restore old states like rasterizer, depth stencil, blend state?
         }
+        
+        public Rectangle Bounds() {
+            if (_vertexCount == 0) return Rectangle.Empty;
+
+            var xMin = float.MaxValue;
+            var xMax = float.MinValue;
+            var yMin = float.MaxValue;
+            var yMax = float.MinValue;
+            var zMin = float.MaxValue;
+            var zMax = float.MinValue;
+
+            for (int i = 0; i < _vertexCount; i++) {
+                var v = _vertices[i].Position;
+                xMin = MathF.Min(xMin, v.X);
+                xMax = MathF.Max(xMax, v.X);
+                yMin = MathF.Min(yMin, v.Y);
+                yMax = MathF.Max(yMax, v.Y);
+                zMin = MathF.Min(zMin, v.Z);
+                zMax = MathF.Max(zMax, v.Z);
+            }
+
+            return new Rectangle((int)xMin, (int)yMin, (int)(xMax - xMin), (int)(yMax - yMin));
+        }
 
         private void Flush() {
             if (_triangleCount == 0) return;


### PR DESCRIPTION
Closes #6 

This PR adds a `Bounds` method to the `ShapeBatch` class, which calculates its [minimum bounding rectangle](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle) (AABB).  