### PR TITLE
Add GPU scissor rect API via SDF masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ monodroid*.msi
 
 apos-docs/
 artifacts/
+
+.vs/

--- a/Source/Content/apos-shapes.fx
+++ b/Source/Content/apos-shapes.fx
@@ -511,7 +511,6 @@ float4 SpritePixelShader(PixelInput p) : SV_TARGET {
     bc = lerp(bc, float4(bc.rgb, 0.0), smoothstep(0.0, 1.0, Gradient(10.0, float4(-aaSize, 0.0, 0.0, 0.0), p.TexCoord.xy, d - aaSize, aaSize, float2(0.0, 0.0))));
 
     float4 result = OkLabToRgb(lerp(fc, bc, smoothstep(0.0, 1.0, Gradient(10.0, float4(-aaSize, 0.0, 0.0, 0.0), p.TexCoord.xy, d + lineSize, aaSize, float2(0.0, 0.0)))));
-
     result.rgb *= result.a;
 
     return result;

--- a/Source/Content/apos-shapes.fx
+++ b/Source/Content/apos-shapes.fx
@@ -24,6 +24,7 @@ struct VertexInput {
     float4 Meta2 : TEXCOORD6;
     float4 Meta3 : TEXCOORD7;
     float4 Meta4 : TEXCOORD8;
+    float4 ClipRectangle : TEXCOORD9;
 };
 struct PixelInput {
     float4 Position : SV_Position0;
@@ -36,6 +37,7 @@ struct PixelInput {
     float4 Meta2 : TEXCOORD6;
     float4 Meta3 : TEXCOORD7;
     float4 Meta4 : TEXCOORD8;
+    float4 ClipRectangle : TEXCOORD9;
 };
 
 // https://iquilezles.org/www/articles/distfunctions2d/distfunctions2d.htm
@@ -434,9 +436,26 @@ PixelInput SpriteVertexShader(VertexInput v) {
     output.Meta2 = v.Meta2;
     output.Meta3 = v.Meta3;
     output.Meta4 = v.Meta4;
+    output.ClipRectangle = v.ClipRectangle;
     return output;
 }
 float4 SpritePixelShader(PixelInput p) : SV_TARGET {
+    float clipRatio = frac(p.ClipRectangle.x);
+    float2 clipPos = float2(floor(p.ClipRectangle.x), p.ClipRectangle.y);
+    float2 clipSize = p.ClipRectangle.zw;
+    float clipRadius = clipRatio * min(clipSize.x, clipSize.y) * 0.5;
+
+    float2 center = clipPos + clipSize * 0.5;
+    float2 q = abs(p.Position.xy - center) - clipSize * 0.5 + clipRadius;
+    float sdf = min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - clipRadius;
+
+    float clipMask = 1.0 - step(0.0, sdf);
+    float hasClip = sign(clipSize.x) * sign(clipSize.y);
+    clipMask = lerp(1.0, clipMask, hasClip);
+    
+    if (clipMask < 0.5f)
+        return float4(0, 0, 0, 0);
+    
     float ps = p.Meta2.x;
     float aaSize = ps * p.Meta2.y;
     float sdfSize = p.Meta1.z;
@@ -492,6 +511,7 @@ float4 SpritePixelShader(PixelInput p) : SV_TARGET {
     bc = lerp(bc, float4(bc.rgb, 0.0), smoothstep(0.0, 1.0, Gradient(10.0, float4(-aaSize, 0.0, 0.0, 0.0), p.TexCoord.xy, d - aaSize, aaSize, float2(0.0, 0.0))));
 
     float4 result = OkLabToRgb(lerp(fc, bc, smoothstep(0.0, 1.0, Gradient(10.0, float4(-aaSize, 0.0, 0.0, 0.0), p.TexCoord.xy, d + lineSize, aaSize, float2(0.0, 0.0)))));
+
     result.rgb *= result.a;
 
     return result;

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -5,7 +5,6 @@ using FontStashSharp.Interfaces;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using MonoGame.Extended;
 
 namespace Apos.Shapes {

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -14,8 +14,7 @@ namespace Apos.Shapes {
 
             if (effect == null) {
                 _effect = content.Load<Effect>("apos-shapes");
-            }
-            else {
+            } else {
                 _effect = effect;
             }
 
@@ -37,15 +36,13 @@ namespace Apos.Shapes {
         public void Begin(Matrix? view = null, Matrix? projection = null, BlendState? blendState = null, SamplerState? samplerState = null, DepthStencilState? depthStencilState = null, RasterizerState? rasterizerState = null) {
             if (view != null) {
                 _view = view.Value;
-            }
-            else {
+            } else {
                 _view = Matrix.Identity;
             }
 
             if (projection != null) {
                 _projection = projection.Value;
-            }
-            else {
+            } else {
                 Viewport viewport = _graphicsDevice.Viewport;
                 _projection = Matrix.CreateOrthographicOffCenter(0, viewport.Width, viewport.Height, 0, 0, 1);
             }
@@ -57,13 +54,13 @@ namespace Apos.Shapes {
             _depthStencilState = depthStencilState ?? DepthStencilState.None;
             _rasterizerState = rasterizerState ?? RasterizerState.CullCounterClockwise;
         }
-        public void SetScissorRect(Rectangle rectangle, int rounding = 0) {
-            _scissorRectangle = rectangle with { Y = _graphicsDevice.Viewport.Height - rectangle.Y - rectangle.Height }; // flipping is required as i sussed out, i'm hoping that _graphicsDevice.Viewport.Height is the right to use :)
-            _scissorRectangleRounding = rounding;
+        public void SetClipRectangle(Rectangle rectangle, int rounding = 0) {
+            _clipRectangle = rectangle; // flipping is required as i sussed out, i'm hoping that _graphicsDevice.Viewport.Height is the right to use :)
+            _clipRectangleRounding = rounding;
         }
-        public void ResetScissorRect() {
-            _scissorRectangle = Rectangle.Empty;
-            _scissorRectangleRounding = 0;
+        public void ResetClipRectangle() {
+            _clipRectangle = Rectangle.Empty;
+            _clipRectangleRounding = 0;
         }
         public void DrawCircle(Vector2 center, float radius, Gradient fill, Gradient border, float thickness = 1f, float aaSize = 1.5f) {
             EnsureSizeOrDouble(ref _vertices, _vertexCount + 4);
@@ -79,10 +76,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, 0f);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -139,10 +136,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -195,10 +192,10 @@ namespace Apos.Shapes {
 
             if (!fill.IsLocal || !border.IsLocal) GradientToLocalSpace(ref fill, ref border, a, MathF.Atan2(b.Y - a.Y, b.X - a.X));
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(width1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(width1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(width1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(width1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -254,10 +251,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -318,10 +315,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -377,13 +374,11 @@ namespace Apos.Shapes {
                 longestSide = sideA;
                 A = a;
                 B = b;
-            }
-            else if (sideB > sideC) {
+            } else if (sideB > sideC) {
                 longestSide = sideB;
                 A = b;
                 B = c;
-            }
-            else {
+            } else {
                 longestSide = sideC;
                 A = c;
                 B = a;
@@ -416,10 +411,10 @@ namespace Apos.Shapes {
             B = new Vector2(inCenterX + (ratioDistance * (b.X - inCenterX)), inCenterY + (ratioDistance * (b.Y - inCenterY)));
             C = new Vector2(inCenterX + (ratioDistance * (c.X - inCenterX)), inCenterY + (ratioDistance * (c.Y - inCenterY)));
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), topLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), topRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), bottomRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), bottomLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), topLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), topRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), bottomRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), bottomLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -469,10 +464,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -530,10 +525,10 @@ namespace Apos.Shapes {
             GradientToLocalSpace(ref fill, ref border, center, rotation);
             GradientToWorldSpace(ref fill, ref border, new Vector2(0, 0), -rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -592,10 +587,10 @@ namespace Apos.Shapes {
             GradientToLocalSpace(ref fill, ref border, center, rotation);
             GradientToWorldSpace(ref fill, ref border, new Vector2(0, 0), -rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -626,8 +621,7 @@ namespace Apos.Shapes {
         public void Draw(Texture2D texture, Matrix3x2 world, Matrix3x2? source = null, Color? mask = null) {
             if (_texture == null) {
                 _texture = texture;
-            }
-            else if (_texture != texture) {
+            } else if (_texture != texture) {
                 Flush();
                 _texture = texture;
             }
@@ -644,8 +638,7 @@ namespace Apos.Shapes {
                 topRight = new Vector2(texture.Width, 0);
                 bottomRight = new Vector2(texture.Width, texture.Height);
                 bottomLeft = new Vector2(0, texture.Height);
-            }
-            else {
+            } else {
                 topLeft = Vector2.Transform(new Vector2(0f, 0f), source.Value);
                 topRight = Vector2.Transform(new Vector2(1f, 0f), source.Value);
                 bottomRight = Vector2.Transform(new Vector2(1f, 1f), source.Value);
@@ -659,10 +652,10 @@ namespace Apos.Shapes {
 
             Gradient g = new(Vector2.Zero, mask ?? Color.White, Vector2.Zero, mask ?? Color.White, Gradient.Shape.None);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(wTopLeft.X, wTopLeft.Y, 0f), GetUV(texture, topLeft), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(wTopRight.X, wTopRight.Y, 0f), GetUV(texture, topRight), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(wBottomRight.X, wBottomRight.Y, 0f), GetUV(texture, bottomRight), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(wBottomLeft.X, wBottomLeft.Y, 0f), GetUV(texture, bottomLeft), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(wTopLeft.X, wTopLeft.Y, 0f), GetUV(texture, topLeft), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(wTopRight.X, wTopRight.Y, 0f), GetUV(texture, topRight), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(wBottomRight.X, wBottomRight.Y, 0f), GetUV(texture, bottomRight), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(wBottomLeft.X, wBottomLeft.Y, 0f), GetUV(texture, bottomLeft), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -745,8 +738,7 @@ namespace Apos.Shapes {
         private void DrawStringTexture(Texture2D texture, ref VertexPositionColorTexture topLeft, ref VertexPositionColorTexture topRight, ref VertexPositionColorTexture bottomLeft, ref VertexPositionColorTexture bottomRight) {
             if (_fontTexture == null) {
                 _fontTexture = texture;
-            }
-            else if (_fontTexture != texture) {
+            } else if (_fontTexture != texture) {
                 Flush();
                 _fontTexture = texture;
             }
@@ -759,10 +751,10 @@ namespace Apos.Shapes {
             Gradient gBottomRight = new(Vector2.Zero, bottomRight.Color, Vector2.Zero, bottomRight.Color, Gradient.Shape.None);
             Gradient gBottomLeft = new(Vector2.Zero, bottomLeft.Color, Vector2.Zero, bottomLeft.Color, Gradient.Shape.None);
 
-            _vertices[_vertexCount + 0] = new VertexShape(topLeft.Position, topLeft.TextureCoordinate, 10f, gTopLeft, gTopLeft, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 1] = new VertexShape(topRight.Position, topRight.TextureCoordinate, 10f, gTopRight, gTopRight, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 2] = new VertexShape(bottomRight.Position, bottomRight.TextureCoordinate, 10f, gBottomRight, gBottomRight, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
-            _vertices[_vertexCount + 3] = new VertexShape(bottomLeft.Position, bottomLeft.TextureCoordinate, 10f, gBottomLeft, gBottomLeft, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 0] = new VertexShape(topLeft.Position, topLeft.TextureCoordinate, 10f, gTopLeft, gTopLeft, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(topRight.Position, topRight.TextureCoordinate, 10f, gTopRight, gTopRight, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(bottomRight.Position, bottomRight.TextureCoordinate, 10f, gBottomRight, gBottomRight, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(bottomLeft.Position, bottomLeft.TextureCoordinate, 10f, gBottomLeft, gBottomLeft, 0f, 1f, _pixelSize, clipRect: _clipRectangle, clipRounding: _clipRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -936,7 +928,7 @@ namespace Apos.Shapes {
 
         private readonly FontStashRenderer _fsr;
 
-        private Rectangle _scissorRectangle = Rectangle.Empty; //Empty(specifically of Zero Size) scissor rect means no clipping
-        private int _scissorRectangleRounding;
+        private Rectangle _clipRectangle = Rectangle.Empty; //Empty(specifically of Zero Size) scissor rect means no clipping
+        private int _clipRectangleRounding;
     }
 }

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -5,6 +5,7 @@ using FontStashSharp.Interfaces;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using MonoGame.Extended;
 
 namespace Apos.Shapes {
@@ -14,7 +15,8 @@ namespace Apos.Shapes {
 
             if (effect == null) {
                 _effect = content.Load<Effect>("apos-shapes");
-            } else {
+            }
+            else {
                 _effect = effect;
             }
 
@@ -36,13 +38,15 @@ namespace Apos.Shapes {
         public void Begin(Matrix? view = null, Matrix? projection = null, BlendState? blendState = null, SamplerState? samplerState = null, DepthStencilState? depthStencilState = null, RasterizerState? rasterizerState = null) {
             if (view != null) {
                 _view = view.Value;
-            } else {
+            }
+            else {
                 _view = Matrix.Identity;
             }
 
             if (projection != null) {
                 _projection = projection.Value;
-            } else {
+            }
+            else {
                 Viewport viewport = _graphicsDevice.Viewport;
                 _projection = Matrix.CreateOrthographicOffCenter(0, viewport.Width, viewport.Height, 0, 0, 1);
             }
@@ -53,6 +57,14 @@ namespace Apos.Shapes {
             _samplerState = samplerState ?? SamplerState.LinearClamp;
             _depthStencilState = depthStencilState ?? DepthStencilState.None;
             _rasterizerState = rasterizerState ?? RasterizerState.CullCounterClockwise;
+        }
+        public void SetScissorRect(Rectangle rectangle, int rounding = 0) {
+            _scissorRectangle = rectangle with { Y = _graphicsDevice.Viewport.Height - rectangle.Y - rectangle.Height }; // flipping is required as i sussed out, i'm hoping that _graphicsDevice.Viewport.Height is the right to use :)
+            _scissorRectangleRounding = rounding;
+        }
+        public void ResetScissorRect() {
+            _scissorRectangle = Rectangle.Empty;
+            _scissorRectangleRounding = 0;
         }
         public void DrawCircle(Vector2 center, float radius, Gradient fill, Gradient border, float thickness = 1f, float aaSize = 1.5f) {
             EnsureSizeOrDouble(ref _vertices, _vertexCount + 4);
@@ -68,10 +80,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, 0f);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius1, -radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 0f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -84,7 +96,7 @@ namespace Apos.Shapes {
             DrawCircle(center, radius, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, aaSize);
         }
         public void DrawCircle(Vector2 center, float radius, Color fill, Color border, float thickness = 1f, float aaSize = 1.5f) {
-            DrawCircle(center, radius, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero,  border, Gradient.Shape.None), thickness, aaSize);
+            DrawCircle(center, radius, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, aaSize);
         }
         public void FillCircle(Vector2 center, float radius, Color c, float aaSize = 1.5f) {
             DrawCircle(center, radius, c, c, 0f, aaSize);
@@ -128,10 +140,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(half1.X, -half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-half1.X, half1.Y), 1f, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -184,10 +196,10 @@ namespace Apos.Shapes {
 
             if (!fill.IsLocal || !border.IsLocal) GradientToLocalSpace(ref fill, ref border, a, MathF.Atan2(b.Y - a.Y, b.X - a.X));
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(width1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(width1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(width1, -radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(width1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius1, radius1), 2f, fill, border, thickness, radius, _pixelSize, width, aaSize: aaSize, rounded: radius, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -243,10 +255,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(size.X, -size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-size.X, size.Y), 3f, fill, border, thickness, radius, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -307,10 +319,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(halfWidth1, -incircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-halfWidth1, circumcircle1), 4f, fill, border, thickness, halfWidth, _pixelSize, aaSize: aaSize, rounded: rounded, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -366,11 +378,13 @@ namespace Apos.Shapes {
                 longestSide = sideA;
                 A = a;
                 B = b;
-            } else if (sideB > sideC) {
+            }
+            else if (sideB > sideC) {
                 longestSide = sideB;
                 A = b;
                 B = c;
-            } else {
+            }
+            else {
                 longestSide = sideC;
                 A = c;
                 B = a;
@@ -403,10 +417,10 @@ namespace Apos.Shapes {
             B = new Vector2(inCenterX + (ratioDistance * (b.X - inCenterX)), inCenterY + (ratioDistance * (b.Y - inCenterY)));
             C = new Vector2(inCenterX + (ratioDistance * (c.X - inCenterX)), inCenterY + (ratioDistance * (c.Y - inCenterY)));
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), topLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), topRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), bottomRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), bottomLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), topLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), topRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), bottomRight, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), bottomLeft, 5f, fill, border, thickness, A.X, _pixelSize, height: A.Y, aaSize: aaSize, rounded: rounded, a: B.X, b: B.Y, c: C.X, d: C.Y, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -456,10 +470,10 @@ namespace Apos.Shapes {
 
             GradientToLocalSpace(ref fill, ref border, center, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius4), 6f, fill, border, thickness, radius1, _pixelSize, radius2, aaSize: aaSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -517,10 +531,10 @@ namespace Apos.Shapes {
             GradientToLocalSpace(ref fill, ref border, center, rotation);
             GradientToWorldSpace(ref fill, ref border, new Vector2(0, 0), -rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 7f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: sin, b: cos, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -579,10 +593,10 @@ namespace Apos.Shapes {
             GradientToLocalSpace(ref fill, ref border, center, rotation);
             GradientToWorldSpace(ref fill, ref border, new Vector2(0, 0), -rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(radius3, -radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-radius3, radius3), 8f, fill, border, thickness, radius1, _pixelSize, aaSize: aaSize, a: cos, b: sin, c: radius2, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -613,7 +627,8 @@ namespace Apos.Shapes {
         public void Draw(Texture2D texture, Matrix3x2 world, Matrix3x2? source = null, Color? mask = null) {
             if (_texture == null) {
                 _texture = texture;
-            } else if (_texture != texture) {
+            }
+            else if (_texture != texture) {
                 Flush();
                 _texture = texture;
             }
@@ -630,7 +645,8 @@ namespace Apos.Shapes {
                 topRight = new Vector2(texture.Width, 0);
                 bottomRight = new Vector2(texture.Width, texture.Height);
                 bottomLeft = new Vector2(0, texture.Height);
-            } else {
+            }
+            else {
                 topLeft = Vector2.Transform(new Vector2(0f, 0f), source.Value);
                 topRight = Vector2.Transform(new Vector2(1f, 0f), source.Value);
                 bottomRight = Vector2.Transform(new Vector2(1f, 1f), source.Value);
@@ -644,10 +660,10 @@ namespace Apos.Shapes {
 
             Gradient g = new(Vector2.Zero, mask ?? Color.White, Vector2.Zero, mask ?? Color.White, Gradient.Shape.None);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(wTopLeft.X, wTopLeft.Y, 0f), GetUV(texture, topLeft), 9f, g, g, 0f, 1f, _pixelSize);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(wTopRight.X, wTopRight.Y, 0f), GetUV(texture, topRight), 9f, g, g, 0f, 1f, _pixelSize);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(wBottomRight.X, wBottomRight.Y, 0f), GetUV(texture, bottomRight), 9f, g, g, 0f, 1f, _pixelSize);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(wBottomLeft.X, wBottomLeft.Y, 0f), GetUV(texture, bottomLeft), 9f, g, g, 0f, 1f, _pixelSize);
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(wTopLeft.X, wTopLeft.Y, 0f), GetUV(texture, topLeft), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(wTopRight.X, wTopRight.Y, 0f), GetUV(texture, topRight), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(wBottomRight.X, wBottomRight.Y, 0f), GetUV(texture, bottomRight), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(wBottomLeft.X, wBottomLeft.Y, 0f), GetUV(texture, bottomLeft), 9f, g, g, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -730,7 +746,8 @@ namespace Apos.Shapes {
         private void DrawStringTexture(Texture2D texture, ref VertexPositionColorTexture topLeft, ref VertexPositionColorTexture topRight, ref VertexPositionColorTexture bottomLeft, ref VertexPositionColorTexture bottomRight) {
             if (_fontTexture == null) {
                 _fontTexture = texture;
-            } else if (_fontTexture != texture) {
+            }
+            else if (_fontTexture != texture) {
                 Flush();
                 _fontTexture = texture;
             }
@@ -743,10 +760,10 @@ namespace Apos.Shapes {
             Gradient gBottomRight = new(Vector2.Zero, bottomRight.Color, Vector2.Zero, bottomRight.Color, Gradient.Shape.None);
             Gradient gBottomLeft = new(Vector2.Zero, bottomLeft.Color, Vector2.Zero, bottomLeft.Color, Gradient.Shape.None);
 
-            _vertices[_vertexCount + 0] = new VertexShape(topLeft.Position, topLeft.TextureCoordinate, 10f, gTopLeft, gTopLeft, 0f, 1f, _pixelSize);
-            _vertices[_vertexCount + 1] = new VertexShape(topRight.Position, topRight.TextureCoordinate, 10f, gTopRight, gTopRight, 0f, 1f, _pixelSize);
-            _vertices[_vertexCount + 2] = new VertexShape(bottomRight.Position, bottomRight.TextureCoordinate, 10f, gBottomRight, gBottomRight, 0f, 1f, _pixelSize);
-            _vertices[_vertexCount + 3] = new VertexShape(bottomLeft.Position, bottomLeft.TextureCoordinate, 10f, gBottomLeft, gBottomLeft, 0f, 1f, _pixelSize);
+            _vertices[_vertexCount + 0] = new VertexShape(topLeft.Position, topLeft.TextureCoordinate, 10f, gTopLeft, gTopLeft, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 1] = new VertexShape(topRight.Position, topRight.TextureCoordinate, 10f, gTopRight, gTopRight, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 2] = new VertexShape(bottomRight.Position, bottomRight.TextureCoordinate, 10f, gBottomRight, gBottomRight, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
+            _vertices[_vertexCount + 3] = new VertexShape(bottomLeft.Position, bottomLeft.TextureCoordinate, 10f, gBottomLeft, gBottomLeft, 0f, 1f, _pixelSize, clipRect: _scissorRectangle, clipRounding: _scissorRectangleRounding);
 
             _triangleCount += 2;
             _vertexCount += 4;
@@ -919,5 +936,8 @@ namespace Apos.Shapes {
         private uint _fromVertex = 0;
 
         private readonly FontStashRenderer _fsr;
+
+        private Rectangle _scissorRectangle = Rectangle.Empty; //Empty(specifically of Zero Size) scissor rect means no clipping
+        private int _scissorRectangleRounding;
     }
 }

--- a/Source/ShapeVertex.cs
+++ b/Source/ShapeVertex.cs
@@ -7,7 +7,7 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Apos.Shapes {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct VertexShape : IVertexType {
-        public VertexShape(Vector3 position, Vector2 textureCoordinate, float shape, Gradient fill, Gradient border, float thickness, float sdfSize, float pixelSize, float height = 1.0f, float aaSize = 2f, float rounded = 0f, float a = 0f, float b = 0f, float c = 0f, float d = 0f) {
+        public VertexShape(Vector3 position, Vector2 textureCoordinate, float shape, Gradient fill, Gradient border, float thickness, float sdfSize, float pixelSize, float height = 1.0f, float aaSize = 2f, float rounded = 0f, float a = 0f, float b = 0f, float c = 0f, float d = 0f, Rectangle clipRect = default, int clipRounding = 0) {
             if (thickness <= 0f) {
                 border = fill;
                 thickness = 0f;
@@ -25,6 +25,9 @@ namespace Apos.Shapes {
             Meta2 = new Vector4(pixelSize, aaSize, rounded, Pair(Pair((int)fill.S, (int)fill.RS), Pair((int)border.S, (int)border.RS)));
             Meta3 = new Vector4(a, b, c, d);
             Meta4 = new Vector4(fill.AOffset, fill.BOffset, border.AOffset, border.BOffset);
+            float maxRadius = MathF.Min(clipRect.Width, clipRect.Height) * 0.5f;
+            float ratio = maxRadius > 0f ? Math.Clamp(clipRounding, 0f, maxRadius) / maxRadius : 0f;
+            ClipRectangle = new Vector4(clipRect.X + ratio, clipRect.Y, clipRect.Width, clipRect.Height);
         }
 
         public Vector3 Position;
@@ -37,6 +40,7 @@ namespace Apos.Shapes {
         public Vector4 Meta2;
         public Vector4 Meta3;
         public Vector4 Meta4;
+        public Vector4 ClipRectangle;
         public static readonly VertexDeclaration VertexDeclaration;
 
         readonly VertexDeclaration IVertexType.VertexDeclaration => VertexDeclaration;
@@ -71,7 +75,8 @@ namespace Apos.Shapes {
                 left.Meta1 == right.Meta1 &&
                 left.Meta2 == right.Meta2 &&
                 left.Meta3 == right.Meta3 &&
-                left.Meta4 == right.Meta4;
+                left.Meta4 == right.Meta4 &&
+                left.ClipRectangle == right.ClipRectangle;
         }
 
         public static bool operator !=(VertexShape left, VertexShape right) {
@@ -101,6 +106,7 @@ namespace Apos.Shapes {
                 GetVertexElement(ref offset, VertexElementFormat.Vector4, VertexElementUsage.TextureCoordinate, 6),
                 GetVertexElement(ref offset, VertexElementFormat.Vector4, VertexElementUsage.TextureCoordinate, 7),
                 GetVertexElement(ref offset, VertexElementFormat.Vector4, VertexElementUsage.TextureCoordinate, 8),
+                GetVertexElement(ref offset, VertexElementFormat.Vector4, VertexElementUsage.TextureCoordinate, 9),
             };
             VertexDeclaration = new VertexDeclaration(elements);
         }
@@ -125,6 +131,7 @@ namespace Apos.Shapes {
             [VertexElementFormat.NormalizedShort4] = 8,
             [VertexElementFormat.HalfVector2] = 4,
             [VertexElementFormat.HalfVector4] = 8,
+            [VertexElementFormat.HalfVector4] = 8,
         };
 
         private static Vector4 PairColors(Color a, Color b) {
@@ -141,7 +148,8 @@ namespace Apos.Shapes {
             if (f2 < f1) {
                 a = f2;
                 b = f1;
-            } else {
+            }
+            else {
                 a = f1;
                 b = f2 - f1;
             }

--- a/Source/ShapeVertex.cs
+++ b/Source/ShapeVertex.cs
@@ -131,7 +131,6 @@ namespace Apos.Shapes {
             [VertexElementFormat.NormalizedShort4] = 8,
             [VertexElementFormat.HalfVector2] = 4,
             [VertexElementFormat.HalfVector4] = 8,
-            [VertexElementFormat.HalfVector4] = 8,
         };
 
         private static Vector4 PairColors(Color a, Color b) {
@@ -148,8 +147,7 @@ namespace Apos.Shapes {
             if (f2 < f1) {
                 a = f2;
                 b = f1;
-            }
-            else {
+            } else {
                 a = f1;
                 b = f2 - f1;
             }


### PR DESCRIPTION
Closes #22
here's a showcase:
![Showcase](https://github.com/user-attachments/assets/041e95de-9e07-40b1-be8f-56f4a629a607)

Implements GPU-side scissor cropping via SDF masking. The clip region is passed as a Vertex Element (Vector4, meets the SM 3.0 max elements!), so multiple SetScissorRect / ResetScissorRect regions can coexist in a single draw call.

here's the API future look:

```csharp
_shapeBatch.Begin();

_shapeBatch.SetScissorRect(clipRect, rounding);
// ... draws clipped here
_shapeBatch.ResetScissorRect();

// ... draws unclipped here


//repeat for as much as wanted

_shapeBatch.End(); // still one draw call!!
```