### PR TITLE
Add per-corner radii for DrawRectangle

### DIFF
--- a/Source/Content/apos-shapes.fx
+++ b/Source/Content/apos-shapes.fx
@@ -45,7 +45,6 @@ float BoxSDF(float2 p, float2 b) {
     float2 d = abs(p) - b;
     return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
 }
-// r packed as (TR, BR, TL, BL) in shader/Meta2 space (+y is DOWN).
 float RoundBoxSDF(float2 p, float2 b, float4 r) {
     r.xy = (p.x > 0.0) ? r.xy : r.zw;
     r.x  = (p.y > 0.0) ? r.y  : r.x;

--- a/Source/Content/apos-shapes.fx
+++ b/Source/Content/apos-shapes.fx
@@ -45,6 +45,13 @@ float BoxSDF(float2 p, float2 b) {
     float2 d = abs(p) - b;
     return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
 }
+// r packed as (TR, BR, TL, BL) in shader/Meta2 space (+y is DOWN).
+float RoundBoxSDF(float2 p, float2 b, float4 r) {
+    r.xy = (p.x > 0.0) ? r.xy : r.zw;
+    r.x  = (p.y > 0.0) ? r.y  : r.x;
+    float2 q = abs(p) - b + r.x;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r.x;
+}
 float SegmentSDF(float2 p, float2 a, float2 b) {
     float2 ba = b - a;
     float2 pa = p - a;
@@ -453,7 +460,7 @@ float4 SpritePixelShader(PixelInput p) : SV_TARGET {
     if (shape < 0.5) {
         d = CircleSDF(p.TexCoord.xy, sdfSize);
     } else if (shape < 1.5) {
-        d = BoxSDF(p.TexCoord.xy, float2(sdfSize, p.Meta1.w));
+        d = RoundBoxSDF(p.TexCoord.xy, float2(sdfSize, p.Meta1.w), p.Meta2);
     } else if (shape < 2.5) {
         d = SegmentSDF(p.TexCoord.xy, float2(0.0, 0.0), float2(p.Meta1.w, 0.0));
     } else if (shape < 3.5) {

--- a/Source/CornerRadii.cs
+++ b/Source/CornerRadii.cs
@@ -1,0 +1,22 @@
+namespace Apos.Shapes {
+    public readonly struct CornerRadii {
+        public readonly float TopLeft;
+        public readonly float TopRight;
+        public readonly float BottomRight;
+        public readonly float BottomLeft;
+
+        public CornerRadii(float uniform) {
+            TopLeft = uniform;
+            TopRight = uniform;
+            BottomRight = uniform;
+            BottomLeft = uniform;
+        }
+
+        public CornerRadii(float topLeft, float topRight, float bottomRight, float bottomLeft) {
+            TopLeft = topLeft;
+            TopRight = topRight;
+            BottomRight = bottomRight;
+            BottomLeft = bottomLeft;
+        }
+    }
+}

--- a/Source/CornerRadii.cs
+++ b/Source/CornerRadii.cs
@@ -12,6 +12,20 @@ namespace Apos.Shapes {
             BottomLeft = uniform;
         }
 
+        public CornerRadii(float topLeftAndBottomRight, float topRightAndBottomLeft) {
+            TopLeft = topLeftAndBottomRight;
+            TopRight = topRightAndBottomLeft;
+            BottomRight = topLeftAndBottomRight;
+            BottomLeft = topRightAndBottomLeft;
+        }
+
+        public CornerRadii(float topLeft, float topRightAndBottomLeft, float bottomRight) {
+            TopLeft = topLeft;
+            TopRight = topRightAndBottomLeft;
+            BottomRight = bottomRight;
+            BottomLeft = topRightAndBottomLeft;
+        }
+
         public CornerRadii(float topLeft, float topRight, float bottomRight, float bottomLeft) {
             TopLeft = topLeft;
             TopRight = topRight;

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -106,19 +106,21 @@ namespace Apos.Shapes {
             DrawCircle(center, radius, new Gradient(Vector2.Zero, Color.Transparent, Vector2.Zero, Color.Transparent, Gradient.Shape.None), g, thickness, rotation, aaSize);
         }
 
-        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
             EnsureSizeOrDouble(ref _vertices, _vertexCount + 4);
             _indicesChanged = EnsureSizeOrDouble(ref _indices, _indexCount + 6) || _indicesChanged;
 
-            rounded = MathF.Min(MathF.Min(rounded, size.X / 2f), size.Y / 2f);
+            float maxR = MathF.Min(size.X, size.Y) / 2f;
+            float rTL = MathHelper.Clamp(cornerRadii.TopLeft,     0f, maxR);
+            float rTR = MathHelper.Clamp(cornerRadii.TopRight,    0f, maxR);
+            float rBR = MathHelper.Clamp(cornerRadii.BottomRight, 0f, maxR);
+            float rBL = MathHelper.Clamp(cornerRadii.BottomLeft,  0f, maxR);
 
             float aaOffset = _pixelSize * aaSize;
             Vector2 xy1 = xy - new Vector2(aaOffset); // Account for AA.
             Vector2 size1 = size + new Vector2(aaOffset * 2f); // Account for AA.
             Vector2 half = size / 2f;
             Vector2 half1 = half + new Vector2(aaOffset); // Account for AA.
-
-            half -= new Vector2(rounded);
 
             var topLeft = xy1;
             var topRight = xy1 + new Vector2(size1.X, 0);
@@ -135,35 +137,65 @@ namespace Apos.Shapes {
 
             GradientToWorld(ref fill, ref border, xy + half, -half, rotation);
 
-            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-half1.X, -half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(half1.X, -half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(half1.X, half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
-            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-half1.X, half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: rounded);
+            // Shader Meta2 packs (TR, BR, TL, BL) to match RoundBoxSDF's quadrant selector.
+            float rA = rTR;
+            float rB = rBR;
+            float rC = rTL;
+            float rD = rBL;
+
+            _vertices[_vertexCount + 0] = new VertexShape(new Vector3(topLeft, 0), new Vector2(-half1.X, -half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: 0f, a: rA, b: rB, c: rC, d: rD);
+            _vertices[_vertexCount + 1] = new VertexShape(new Vector3(topRight, 0), new Vector2(half1.X, -half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: 0f, a: rA, b: rB, c: rC, d: rD);
+            _vertices[_vertexCount + 2] = new VertexShape(new Vector3(bottomRight, 0), new Vector2(half1.X, half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: 0f, a: rA, b: rB, c: rC, d: rD);
+            _vertices[_vertexCount + 3] = new VertexShape(new Vector3(bottomLeft, 0), new Vector2(-half1.X, half1.Y), VertexShape.Shape.Rectangle, fill, border, thickness, half.X, _pixelSize, half.Y, aaSize: aaSize, rounded: 0f, a: rA, b: rB, c: rC, d: rD);
 
             _triangleCount += 2;
             _vertexCount += 4;
             _indexCount += 6;
         }
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, fill, border, thickness, new CornerRadii(rounded), rotation, aaSize);
+        }
         public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, rounded, rotation, aaSize);
+        }
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, cornerRadii, rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, rounded, rotation, aaSize);
         }
+        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, cornerRadii, rotation, aaSize);
+        }
         public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, rounded, rotation, aaSize);
+        }
+        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, cornerRadii, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Gradient g, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, g, g, 0f, rounded, rotation, aaSize);
         }
+        public void FillRectangle(Vector2 xy, Vector2 size, Gradient g, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, g, g, 0f, cornerRadii, rotation, aaSize);
+        }
         public void FillRectangle(Vector2 xy, Vector2 size, Color c, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, c, c, 0f, rounded, rotation, aaSize);
+        }
+        public void FillRectangle(Vector2 xy, Vector2 size, Color c, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, c, c, 0f, cornerRadii, rotation, aaSize);
         }
         public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, Color.Transparent, g, thickness, rounded, rotation, aaSize);
         }
+        public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, Color.Transparent, g, thickness, cornerRadii, rotation, aaSize);
+        }
         public void BorderRectangle(Vector2 xy, Vector2 size, Color c, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, Color.Transparent, c, thickness, rounded, rotation, aaSize);
+        }
+        public void BorderRectangle(Vector2 xy, Vector2 size, Color c, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, Color.Transparent, c, thickness, cornerRadii, rotation, aaSize);
         }
 
         public void DrawLine(Vector2 a, Vector2 b, float radius, Gradient fill, Gradient border, float thickness = 1f, float aaSize = 1.5f) {

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -106,7 +106,7 @@ namespace Apos.Shapes {
             DrawCircle(center, radius, new Gradient(Vector2.Zero, Color.Transparent, Vector2.Zero, Color.Transparent, Gradient.Shape.None), g, thickness, rotation, aaSize);
         }
 
-        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
             EnsureSizeOrDouble(ref _vertices, _vertexCount + 4);
             _indicesChanged = EnsureSizeOrDouble(ref _indices, _indexCount + 6) || _indicesChanged;
 
@@ -153,49 +153,49 @@ namespace Apos.Shapes {
             _indexCount += 6;
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, fill, border, thickness, new CornerRadii(rounded), rotation, aaSize);
+            DrawRectangle(xy, size, fill, border, new CornerRadii(rounded), thickness, rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, rounded, rotation, aaSize);
         }
-        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, cornerRadii, rotation, aaSize);
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), cornerRadii, thickness, rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, rounded, rotation, aaSize);
         }
-        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, cornerRadii, rotation, aaSize);
+        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, cornerRadii, thickness, rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, rounded, rotation, aaSize);
         }
-        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, cornerRadii, rotation, aaSize);
+        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), cornerRadii, thickness, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Gradient g, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, g, g, 0f, rounded, rotation, aaSize);
+            DrawRectangle(xy, size, g, g, new CornerRadii(rounded), 0f, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Gradient g, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, g, g, 0f, cornerRadii, rotation, aaSize);
+            DrawRectangle(xy, size, g, g, cornerRadii, 0f, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Color c, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, c, c, 0f, rounded, rotation, aaSize);
+            DrawRectangle(xy, size, c, c, new CornerRadii(rounded), 0f, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Color c, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, c, c, 0f, cornerRadii, rotation, aaSize);
+            DrawRectangle(xy, size, c, c, cornerRadii, 0f, rotation, aaSize);
         }
         public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, Color.Transparent, g, thickness, rounded, rotation, aaSize);
         }
-        public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, Color.Transparent, g, thickness, cornerRadii, rotation, aaSize);
+        public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, Color.Transparent, g, cornerRadii, thickness, rotation, aaSize);
         }
         public void BorderRectangle(Vector2 xy, Vector2 size, Color c, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, Color.Transparent, c, thickness, rounded, rotation, aaSize);
         }
-        public void BorderRectangle(Vector2 xy, Vector2 size, Color c, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, Color.Transparent, c, thickness, cornerRadii, rotation, aaSize);
+        public void BorderRectangle(Vector2 xy, Vector2 size, Color c, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, Color.Transparent, c, cornerRadii, thickness, rotation, aaSize);
         }
 
         public void DrawLine(Vector2 a, Vector2 b, float radius, Gradient fill, Gradient border, float thickness = 1f, float aaSize = 1.5f) {

--- a/Source/ShapeBatch.cs
+++ b/Source/ShapeBatch.cs
@@ -106,7 +106,7 @@ namespace Apos.Shapes {
             DrawCircle(center, radius, new Gradient(Vector2.Zero, Color.Transparent, Vector2.Zero, Color.Transparent, Gradient.Shape.None), g, thickness, rotation, aaSize);
         }
 
-        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
             EnsureSizeOrDouble(ref _vertices, _vertexCount + 4);
             _indicesChanged = EnsureSizeOrDouble(ref _indices, _indexCount + 6) || _indicesChanged;
 
@@ -153,49 +153,49 @@ namespace Apos.Shapes {
             _indexCount += 6;
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, fill, border, new CornerRadii(rounded), thickness, rotation, aaSize);
+            DrawRectangle(xy, size, fill, border, thickness, new CornerRadii(rounded), rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, rounded, rotation, aaSize);
         }
-        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), cornerRadii, thickness, rotation, aaSize);
+        public void DrawRectangle(Vector2 xy, Vector2 size, Gradient fill, Color border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, fill, new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, cornerRadii, rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, rounded, rotation, aaSize);
         }
-        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, cornerRadii, thickness, rotation, aaSize);
+        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Gradient border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), border, thickness, cornerRadii, rotation, aaSize);
         }
         public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, rounded, rotation, aaSize);
         }
-        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), cornerRadii, thickness, rotation, aaSize);
+        public void DrawRectangle(Vector2 xy, Vector2 size, Color fill, Color border, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, new Gradient(Vector2.Zero, fill, Vector2.Zero, fill, Gradient.Shape.None), new Gradient(Vector2.Zero, border, Vector2.Zero, border, Gradient.Shape.None), thickness, cornerRadii, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Gradient g, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, g, g, new CornerRadii(rounded), 0f, rotation, aaSize);
+            DrawRectangle(xy, size, g, g, 0f, rounded, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Gradient g, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, g, g, cornerRadii, 0f, rotation, aaSize);
+            DrawRectangle(xy, size, g, g, 0f, cornerRadii, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Color c, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, c, c, new CornerRadii(rounded), 0f, rotation, aaSize);
+            DrawRectangle(xy, size, c, c, 0f, rounded, rotation, aaSize);
         }
         public void FillRectangle(Vector2 xy, Vector2 size, Color c, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, c, c, cornerRadii, 0f, rotation, aaSize);
+            DrawRectangle(xy, size, c, c, 0f, cornerRadii, rotation, aaSize);
         }
         public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, Color.Transparent, g, thickness, rounded, rotation, aaSize);
         }
-        public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, Color.Transparent, g, cornerRadii, thickness, rotation, aaSize);
+        public void BorderRectangle(Vector2 xy, Vector2 size, Gradient g, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, Color.Transparent, g, thickness, cornerRadii, rotation, aaSize);
         }
         public void BorderRectangle(Vector2 xy, Vector2 size, Color c, float thickness = 1f, float rounded = 0f, float rotation = 0f, float aaSize = 1.5f) {
             DrawRectangle(xy, size, Color.Transparent, c, thickness, rounded, rotation, aaSize);
         }
-        public void BorderRectangle(Vector2 xy, Vector2 size, Color c, CornerRadii cornerRadii, float thickness = 1f, float rotation = 0f, float aaSize = 1.5f) {
-            DrawRectangle(xy, size, Color.Transparent, c, cornerRadii, thickness, rotation, aaSize);
+        public void BorderRectangle(Vector2 xy, Vector2 size, Color c, float thickness, CornerRadii cornerRadii, float rotation = 0f, float aaSize = 1.5f) {
+            DrawRectangle(xy, size, Color.Transparent, c, thickness, cornerRadii, rotation, aaSize);
         }
 
         public void DrawLine(Vector2 a, Vector2 b, float radius, Gradient fill, Gradient border, float thickness = 1f, float aaSize = 1.5f) {


### PR DESCRIPTION
## Summary

Adds independent per-corner radii to rectangles. A new `CornerRadii` struct names each corner (`TopLeft`, `TopRight`, `BottomRight`, `BottomLeft`) and a parallel set of `DrawRectangle` / `FillRectangle` / `BorderRectangle` overloads accept it.

The existing `float rounded` overloads delegate through `new CornerRadii(rounded)`, so all current callers render bit-identically.

## Shader

`BoxSDF` gains a sibling `RoundBoxSDF` that picks the active corner radius from `Meta2` based on the pixel's quadrant — ported from Inigo Quilez's `sdRoundBox` and flipped for the engine's y-down texcoords. The rectangle branch in the pixel shader now calls `RoundBoxSDF`. The generic `d -= TexCoord.z` post-step is unchanged; C# passes `rounded: 0f` for rectangles so it's a no-op for them while remaining active for circle / hexagon / ellipse / etc.

## Vertex layout

No layout change. `Meta2` was previously unused by rectangles (only Triangle / Arc / Ring read it), so the four radii pack into existing space.

## Verification

Tested against `Example/Platforms/DesktopGL` with a rectangle using `CornerRadii(topLeft: 5, topRight: 40, bottomRight: 10, bottomLeft: 25)` — each corner renders at the expected radius. A uniform `CornerRadii(15)` rectangle matches a pre-change `rounded: 15` rectangle exactly. The existing rendered demo (the face) is unchanged.

## Test plan

- [x] `dotnet build Source/Apos.Shapes.csproj` succeeds
- [x] `dotnet build Source/Apos.Shapes.KNI.csproj` succeeds
- [x] `dotnet run --project Example/Platforms/DesktopGL/DesktopGL.csproj` — existing demo renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)