### PR TITLE
Fix Unpair() decoding a packed 0 byte as ~255 on macOS GL

### DIFF
--- a/Source/Content/apos-shapes.fx
+++ b/Source/Content/apos-shapes.fx
@@ -413,10 +413,7 @@ float2 Unpair(float n) {
     float2 result;
 
     float f1 = floor(sqrt(n));
-    // A perfect square's sqrt can land just below the integer on some GL drivers
-    // (macOS returns 254.9999... for sqrt(65025)), so floor() drops a whole step and a
-    // decoded byte that should be 0 comes back as ~255. Nudge f1 back up when (f1+1)^2
-    // still fits within n. Fixes filled shapes rendering with a wrong channel forced high.
+
     if ((f1 + 1.0) * (f1 + 1.0) <= n) {
         f1 += 1.0;
     }

--- a/Source/Content/apos-shapes.fx
+++ b/Source/Content/apos-shapes.fx
@@ -413,6 +413,13 @@ float2 Unpair(float n) {
     float2 result;
 
     float f1 = floor(sqrt(n));
+    // A perfect square's sqrt can land just below the integer on some GL drivers
+    // (macOS returns 254.9999... for sqrt(65025)), so floor() drops a whole step and a
+    // decoded byte that should be 0 comes back as ~255. Nudge f1 back up when (f1+1)^2
+    // still fits within n. Fixes filled shapes rendering with a wrong channel forced high.
+    if ((f1 + 1.0) * (f1 + 1.0) <= n) {
+        f1 += 1.0;
+    }
     float f2 = n - f1 * f1;
     if (f2 < f1) {
         result.x = f2;


### PR DESCRIPTION
## Problem
On macOS's OpenGL driver, filled shapes render with a color channel forced to 1.0 — a black `FillRectangle` comes out **blue**, red → magenta, `Color.Green` (0,128,0) → light blue. Correct on Windows / Direct3D.

## Cause
`Unpair()` inverts the Szudzik pairing that packs two color bytes into one float, using `floor(sqrt(n))`. When the packed value is a **perfect square** — e.g. `pair(0, 255) = 65025 = 255²`, exactly the `(colorByte = 0, alpha = 255)` case for any opaque shape — macOS's GL `sqrt` returns `254.9999…`, so `floor()` yields `254` instead of `255` and the byte decodes as `~255` instead of `0`. Blue is paired with alpha in the fill color, so opaque shapes with `blue = 0` lose their blue channel to `1.0`. Windows is correct because its `sqrt` is correctly rounded.

The meta/gradient decode uses the same function and shares the latent fragility, though those values don't hit perfect squares in common cases.

## Fix
After `floor(sqrt(n))`, bump the root up when `(f1 + 1)² <= n` still holds, recovering the exact integer root regardless of `sqrt` rounding:

```hlsl
float f1 = floor(sqrt(n));
if ((f1 + 1.0) * (f1 + 1.0) <= n) f1 += 1.0;
```

Exact on all platforms, and branch-free after compilation (lowers to a predicated select). If you'd prefer it explicitly branchless, `f1 += step((f1 + 1.0) * (f1 + 1.0), n);` is equivalent.

## Verification
A black `FillRectangle(pos, size, Color.Black, aaSize: 0)` on macOS DesktopGL renders blue before, black after. Verified on macOS arm64 via a downstream consumer (FlatRedBall2) that recompiled the shader with this patch.
